### PR TITLE
Error at do_rootfs due to qemuwrapper dependency lost

### DIFF
--- a/recipes-core/images/rpi-basic-image-rt.bb
+++ b/recipes-core/images/rpi-basic-image-rt.bb
@@ -8,7 +8,7 @@ python () {
 
 DESCRIPTION = "A Raspberry Pi image with PREEMPT-RT kernel and real-time test \
                suite"
-DEPENDS = "(linux-raspberrypi-rt|linux-raspberrypi-rt-dev)"
+DEPENDS += "(linux-raspberrypi-rt|linux-raspberrypi-rt-dev)"
 
 IMAGE_INSTALL += " \
                   linux-firmware-bcm43430 \

--- a/recipes-core/images/rpi-basic-image-xenomai.bb
+++ b/recipes-core/images/rpi-basic-image-xenomai.bb
@@ -8,7 +8,7 @@ python () {
 
 DESCRIPTION = "A Raspberry Pi image with I-pipe/Xenomai kernel and real-time \
                test suite"
-DEPENDS = "linux-raspberrypi-ipipe qemuwrapper-cross"
+DEPENDS += "linux-raspberrypi-ipipe qemuwrapper-cross"
 
 IMAGE_INSTALL += " \
                   linux-firmware-bcm43430 \

--- a/recipes-core/images/rpi-hwup-image-rt.bb
+++ b/recipes-core/images/rpi-hwup-image-rt.bb
@@ -8,7 +8,7 @@ python () {
 
 DESCRIPTION = "A Raspberry Pi image with PREEMPT-RT kernel and real-time test \
                suite"
-DEPENDS = "(linux-raspberrypi-rt|linux-raspberrypi-rt-dev)"
+DEPENDS += "(linux-raspberrypi-rt|linux-raspberrypi-rt-dev)"
 
 IMAGE_INSTALL += " \
                   rt-tests \

--- a/recipes-core/images/rpi-hwup-image-xenomai.bb
+++ b/recipes-core/images/rpi-hwup-image-xenomai.bb
@@ -8,7 +8,7 @@ python () {
 
 DESCRIPTION = "A Raspberry Pi image with I-pipe/Xenomai kernel and real-time \
                test suite"
-DEPENDS = "linux-raspberrypi-ipipe qemuwrapper-cross"
+DEPENDS += "linux-raspberrypi-ipipe qemuwrapper-cross"
 
 IMAGE_INSTALL += " \
                   rt-tests \


### PR DESCRIPTION
Your usage of = rather than += overrides the image.bbclass resulting in qemuwrapper being excluded from the do_rootfs function which in turn, causing an error in the post intercept scripts. Quick fix, add dependencies, don't override them :)